### PR TITLE
fix(seo): pin sitemap to canonical domain

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  siteUrl: process.env.SITE_URL || 'https://sammcnab.co.uk',
+  siteUrl: 'https://sammcnab.co.uk',
   generateRobotsTxt: true,
   exclude: [
     '/api/*',

--- a/src/__tests__/privacy-footprint.test.ts
+++ b/src/__tests__/privacy-footprint.test.ts
@@ -54,6 +54,16 @@ describe('privacy-focused public profile', () => {
     expect(PROJECTS.filter((project) => project.isShow)).toHaveLength(2);
   });
 
+  it('pins generated sitemap URLs to the working apex domain', () => {
+    const sitemapConfig = fs.readFileSync(
+      path.join(repositoryRoot, 'next-sitemap.config.js'),
+      'utf8',
+    );
+
+    expect(sitemapConfig).toContain("siteUrl: 'https://sammcnab.co.uk'");
+    expect(sitemapConfig).not.toContain('process.env.SITE_URL');
+  });
+
   it.each([
     'src/pages/blog/index.tsx',
     'src/pages/guestbook.tsx',


### PR DESCRIPTION
### Summary

Pins generated sitemap URLs to the working apex domain after production verification found that the configured `www` hostname returns HTTP 526.

### Changes

- remove the deploy-time `SITE_URL` override from sitemap generation
- add a regression test for the canonical sitemap origin

### Testing

- `npm run lint` (passes with unchanged pre-existing warnings)
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`
- Gitleaks scan of changed files

### Screenshots

Not applicable; no visual changes.

### Breaking Changes

None.

### Related Issues

None.